### PR TITLE
LinkBuilder can be chained.

### DIFF
--- a/example/src/main/java/com/klinker/android/link_builder_example/MainActivity.java
+++ b/example/src/main/java/com/klinker/android/link_builder_example/MainActivity.java
@@ -45,12 +45,10 @@ public class MainActivity extends Activity {
         // find the text view. Used to create the link builder
         TextView demoText = (TextView) findViewById(R.id.test_text);
 
-        // Add the links
-        LinkBuilder builder = new LinkBuilder(demoText);
-        builder.addLinks(getExampleLinks());
-
-        // force the builder to display and make the links clickable
-        builder.build();
+        // Add the links and make the links clickable
+        new LinkBuilder(demoText)
+                .addLinks(getExampleLinks())
+                .build();
     }
 
     private List<Link> getExampleLinks() {

--- a/library/src/main/java/com/klinker/android/link_builder/LinkBuilder.java
+++ b/library/src/main/java/com/klinker/android/link_builder/LinkBuilder.java
@@ -41,6 +41,9 @@ public class LinkBuilder {
      * @param textView The TextView you will be adding links to.
      */
     public LinkBuilder(TextView textView) {
+        if (textView == null) {
+            throw new IllegalArgumentException("textView is null");
+        }
         this.textView = textView;
     }
 
@@ -48,16 +51,27 @@ public class LinkBuilder {
      * Add a single link to the builder.
      * @param link the rule that you want to link with.
      */
-    public void addLink(Link link) {
+    public LinkBuilder addLink(Link link) {
+        if (link == null) {
+            throw new IllegalArgumentException("link is null");
+        }
         this.links.add(link);
+        return this;
     }
 
     /**
      * Add a list of links to the builder.
      * @param links list of rules you want to link with.
      */
-    public void addLinks(List<Link> links) {
+    public LinkBuilder addLinks(List<Link> links) {
+        if (links == null) {
+            throw new IllegalArgumentException("link list is null");
+        }
+        if (links.isEmpty()) {
+            throw new IllegalArgumentException("link list is empty");
+        }
         this.links.addAll(links);
+        return this;
     }
 
     /**


### PR DESCRIPTION
Hi Luke,

since `LinkBuilder` is a fairly simple class, maybe this was intentionally skipped, but I thought I’d mention it anyway:

I personally would expect to be able to chain a builder instance (just like in the Effective Java 2nd Edition, Item 2). With a simple change that shouldn’t break any existing functionality, we could now do

```
new LinkBuilder(demoText)
    .addLinks(getExampleLinks())
    .addLink(someOtherLink)
    .addLink(andMaybeAnotherLink)
    .build();
```

It’s more of a syntactical sugar than anything else. Let me know what you think.

Cheers,
Tadej