### PR TITLE
fix non-matching patterns bug

### DIFF
--- a/library/src/main/java/com/klinker/android/link_builder/LinkBuilder.java
+++ b/library/src/main/java/com/klinker/android/link_builder/LinkBuilder.java
@@ -78,13 +78,13 @@ public class LinkBuilder {
      * Execute the rules to create the linked text.
      */
     public void build() {
+        // we extract individual links from the patterns
+        turnPatternsToLinks();
+
         // exit if there are no links
         if (links.size() == 0) {
             return;
         }
-
-        // we extract individual links from the patterns
-        turnPatternsToLinks();
 
         // add those links to our spannable text so they can be clicked
         for (Link link : links) {


### PR DESCRIPTION
When using LinkBuilder to highlight all links within a `TextView` using a Pattern there is a bug where all text gets removed from the `TextView`.

Can be reproduced like this:

Set up LinkBuilder with the Patterns.WEB_URL Pattern like this.

```java
Link link = new Link(Patterns.WEB_URL)
    .setOnClickListener(clickedText -> {
        // Do something
    });

new LinkBuilder(textView)
    .addLink(link)
    .build();
```

If `textView` contains a text with a link in it, everything is working as expected.
Example:
```
Visit: https://github.com/klinker24/Android-TextView-LinkBuilder
```
Will show the text with correctly highlighted link in the TextView.


If the text in `textView` does **not** contain any links, the `textView` will be empty after using LinkBuilder (since `spannable`, which is null, will be assigned to `textView.setText`).
Example:
```
Visit the project on Github
```
Will show an empty TextView with the above mentioned LinkBuilder.

By turning Patterns to Links earlier, we can prevent this from happening and `textView`s that don't match the Pattern at all will still retain their text.