### PR TITLE
Make the LinkBuilder accept CharSequence instead of String

### DIFF
--- a/library/src/main/java/com/klinker/android/link_builder/LinkBuilder.kt
+++ b/library/src/main/java/com/klinker/android/link_builder/LinkBuilder.kt
@@ -303,7 +303,7 @@ class LinkBuilder {
         private const val TYPE_TEXT = 1
         private const val TYPE_TEXT_VIEW = 2
 
-        @JvmStatic fun from(context: Context, text: String): LinkBuilder {
+        @JvmStatic fun from(context: Context, text: CharSequence): LinkBuilder {
             return LinkBuilder(TYPE_TEXT)
                     .setContext(context)
                     .setText(text)


### PR DESCRIPTION
This allows to pass in already styled texts (SpannableString and friends) to apply links onto.

This is backwards compatible since `String` implements `CharSequence`